### PR TITLE
Fix shape error in GaussianFilter1d

### DIFF
--- a/deepgazemr/model.py
+++ b/deepgazemr/model.py
@@ -239,4 +239,4 @@ class GaussianFilter1d(nn.Module):
         kernel = kernel / kernel.sum()
 
         # convolve input with gaussian kernel
-        return F.conv1d(x, kernel)
+        return F.conv2d(x, kernel)


### PR DESCRIPTION
The implementation of the Gaussian filter erroneously uses a `conv1d`. This PR changes it to the correct `conv2d` (the Gaussian filter is 1d along a single axis of a 2d tensor).